### PR TITLE
fix/drawio stencil loading crashes on bad stencil responses

### DIFF
--- a/packages/canvas-app/src/loaders.ts
+++ b/packages/canvas-app/src/loaders.ts
@@ -47,5 +47,11 @@ export const loadFileFromUrl = async (
 
 /** @namespace */
 export const FileSystem = {
-  loadFromUrl: async (url: string) => fetch(url.replace('$STENCIL_ROOT', '')).then(r => r.text())
+  loadFromUrl: async (url: string) => {
+    const response = await fetch(url.replace('$STENCIL_ROOT', ''));
+    if (!response.ok) {
+      throw new Error(`Failed to load ${url}: ${response.status} ${response.statusText}`);
+    }
+    return response.text();
+  }
 };

--- a/packages/main/src/appConfig.default.ts
+++ b/packages/main/src/appConfig.default.ts
@@ -9,10 +9,14 @@ import { stencilLoaderBasic } from '@diagram-craft/model/stencilRegistry';
 const random = new Random(Date.now());
 
 if (!window.electronAPI) {
-  FileSystem.loadFromUrl = async (url: string) =>
-    fetch(url.replace('$STENCIL_ROOT', import.meta.env.VITE_STENCIL_ROOT ?? '')).then(r =>
-      r.text()
-    );
+  FileSystem.loadFromUrl = async (url: string) => {
+    const resolvedUrl = url.replace('$STENCIL_ROOT', import.meta.env.VITE_STENCIL_ROOT ?? '');
+    const response = await fetch(resolvedUrl);
+    if (!response.ok) {
+      throw new Error(`Failed to load ${url}: ${response.status} ${response.statusText}`);
+    }
+    return response.text();
+  };
 }
 
 export const defaultAppConfig: AppConfig = {


### PR DESCRIPTION
Adds an explicit HTTP error check when loading stencil files so failed fetches no longer fall through to XML parsing. This makes intermittent stencil-load failures surface as concrete response errors instead of a generic assertion.