### PR TITLE
chore/bump transitive dependency overrides

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,13 +11,13 @@ overrides:
   nanoid: ^3.3.8
   postcss: '>=8.5.10'
   esbuild: ^0.25.0
-  form-data: '>=4.0.4'
+  form-data: '>=4.0.6'
   axios: 1.15.2
   ip-address: 10.1.1
   brace-expansion: 5.0.6
   follow-redirects: '>=1.16.0'
-  js-yaml: '>=4.1.1'
-  tar: '>=7.5.11'
+  js-yaml: '>=4.2.0'
+  tar: '>=7.5.16'
   '@xmldom/xmldom': 0.8.13
   '@tootallnate/once': '>=3.0.1'
   defu: '>=6.1.6'
@@ -3252,8 +3252,8 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   fp-ts@2.16.11:
@@ -3717,8 +3717,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -4971,8 +4971,8 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
-  tar@7.5.15:
-    resolution: {integrity: sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==}
+  tar@7.5.16:
+    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
     engines: {node: '>=18'}
 
   temp-file@3.4.0:
@@ -5664,7 +5664,7 @@ snapshots:
     dependencies:
       axios: 1.15.2
       find-up: 6.3.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       node-gyp-build: 4.8.4
       stack-trace: 1.0.0-pre2
     transitivePeerDependencies:
@@ -5781,7 +5781,7 @@ snapshots:
       ora: 5.4.1
       read-binary-file-arch: 1.0.6
       semver: 7.8.1
-      tar: 7.5.15
+      tar: 7.5.16
       yargs: 17.7.2
     transitivePeerDependencies:
       - supports-color
@@ -6477,7 +6477,7 @@ snapshots:
   '@rollup/plugin-yaml@5.0.0':
     dependencies:
       '@rollup/pluginutils': 5.4.0
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       tosource: 2.0.0-alpha.3
 
   '@rollup/pluginutils@5.4.0':
@@ -7097,7 +7097,7 @@ snapshots:
       hosted-git-info: 4.1.0
       isbinaryfile: 5.0.7
       jiti: 2.7.0
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       json5: 2.2.3
       lazy-val: 1.0.5
       minimatch: 10.2.5
@@ -7106,7 +7106,7 @@ snapshots:
       proper-lockfile: 4.1.2
       resedit: 1.7.2
       semver: 7.7.4
-      tar: 7.5.15
+      tar: 7.5.16
       temp-file: 3.4.0
       tiny-async-pool: 1.3.0
       unzipper: 0.12.3
@@ -7193,7 +7193,7 @@ snapshots:
   axios@1.15.2:
     dependencies:
       follow-redirects: 1.16.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -7272,7 +7272,7 @@ snapshots:
       fs-extra: 10.1.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       sanitize-filename: 1.6.4
       source-map-support: 0.5.21
       stat-mode: 1.0.0
@@ -7301,7 +7301,7 @@ snapshots:
       minipass-pipeline: 1.2.4
       p-map: 7.0.4
       ssri: 12.0.0
-      tar: 7.5.15
+      tar: 7.5.16
       unique-filename: 4.0.0
 
   cacheable-lookup@5.0.4: {}
@@ -7582,7 +7582,7 @@ snapshots:
       findup-sync: 5.0.0
       ignore: 5.3.2
       is-core-module: 2.16.2
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       json5: 2.2.3
       lodash: 4.18.1
       minimatch: 7.4.9
@@ -7623,7 +7623,7 @@ snapshots:
       builder-util: 26.13.0
       fs-extra: 10.1.0
       iconv-lite: 0.6.3
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
     optionalDependencies:
       dmg-license: 1.0.11
     transitivePeerDependencies:
@@ -7717,7 +7717,7 @@ snapshots:
       builder-util: 26.13.0
       builder-util-runtime: 9.6.3
       chalk: 4.1.2
-      form-data: 4.0.5
+      form-data: 4.0.6
       fs-extra: 10.1.0
       lazy-val: 1.0.5
       mime: 2.6.0
@@ -7970,7 +7970,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -8456,7 +8456,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 
@@ -8861,7 +8861,7 @@ snapshots:
       nopt: 8.1.0
       proc-log: 5.0.0
       semver: 7.8.1
-      tar: 7.5.15
+      tar: 7.5.16
       tinyglobby: 0.2.17
       which: 5.0.0
     transitivePeerDependencies:
@@ -9815,7 +9815,7 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  tar@7.5.15:
+  tar@7.5.16:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,13 +28,13 @@ overrides:
   nanoid: ^3.3.8
   postcss: ">=8.5.10"
   esbuild: ^0.25.0
-  form-data: ">=4.0.4"
+  form-data: ">=4.0.6"
   axios: 1.15.2
   ip-address: 10.1.1
   brace-expansion: 5.0.6
   follow-redirects: ">=1.16.0"
-  js-yaml: ">=4.1.1"
-  tar: ">=7.5.11"
+  js-yaml: ">=4.2.0"
+  tar: ">=7.5.16"
   "@xmldom/xmldom": 0.8.13
   "@tootallnate/once": ">=3.0.1"
   defu: ">=6.1.6"


### PR DESCRIPTION
Update pnpm overrides and lockfile entries for `form-data`, `js-yaml`, and `tar` to the newer patched releases.
